### PR TITLE
luks-tools: cleanup logging

### DIFF
--- a/pkg/kdumpcollector/s3store/s3store.go
+++ b/pkg/kdumpcollector/s3store/s3store.go
@@ -230,7 +230,6 @@ func (s awsS3) uploadPart(multipartData *s3.CreateMultipartUploadOutput, part in
 		ETag:       result.ETag,
 		PartNumber: aws.Int64(int64(part)),
 	}
-	log.Info(uploadResult)
 	return uploadResult, nil
 }
 

--- a/pkg/kdumpcollector/sink/sink.go
+++ b/pkg/kdumpcollector/sink/sink.go
@@ -88,7 +88,9 @@ func StartSSHServer() error {
 			return err
 		}
 		_, chans, reqs, err := ssh.NewServerConn(tcpConn, sshConfig)
-		if err != nil {
+		// do not log EOF errors, as they most probably are caused by portscan
+		// or heartbeats.
+		if err != nil && err != io.EOF {
 			log.Error(err)
 		}
 		go ssh.DiscardRequests(reqs)


### PR DESCRIPTION
Strip unneeded logging and ignore ssh EOF errors.

